### PR TITLE
Add a max_size field to the TCP source config parser syntax.

### DIFF
--- a/documentation/content/pony-tutorial/api.md
+++ b/documentation/content/pony-tutorial/api.md
@@ -548,7 +548,11 @@ The class used to define the properties of a Wallaroo TCPSource.
 
 `frame_handler` is a primitive or class that must implement the `FramedSourceHandler` interface.
 
-`TCPSourceConfigCLIParser` is a helper which accepts a `source`, a String representing the Source name and `env.args` which is the arguments provided to the application. These arguments are then parsed to provide a `TCPSourceConfigOptions` which has the source name, host, and service port.
+`TCPSourceConfigCLIParser` is a helper which accepts a `source`, a String representing the Source name and `env.args` which is the arguments provided to the application. These arguments are then parsed to provide a `TCPSourceConfigOptions` which has the source name, host, and service port, and optional maxiumum message size. The format is either `source_name@host:service` or `source_name@host:service:max_size`. For example,
+
+```
+mysource1@3.4.5.6:7100:500000
+```
 
 #### KafkaSource
 

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_coordinator.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_coordinator.pony
@@ -158,6 +158,8 @@ actor TCPSourceCoordinator[In: Any val] is SourceCoordinator
 
     @printf[I32]((pipeline_name + " source will listen (but not yet) on "
           + host + ":" + service + "\n").cstring())
+    @printf[I32]((pipeline_name + " TCP Source max buffer size: "
+          + max_size.string()+ "\n").cstring())
 
     for i in Range(0, _limit) do
       let name = _worker_name + ":" + _pipeline_name + " source " + i.string()


### PR DESCRIPTION
This PR adds an additional field to `TCPSourceConfigCLIParser` such that you can specify a maximum message size per source. The format is either `source_name@host:service` or `source_name@host:service:max_size`.  This should be backward compatible to existing applications.

For example, an app might have a command line like this:
```bash
    --in foo-source@0.0.0.0:7100,bar-source@0.0.0.0:7102:200000000
```
where `foo-source` has the default size of 16384 and `bar-source` 200 MB.